### PR TITLE
Update the vendor of the plugin to CUE Labs

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
     <id>dev.monogon.cuelang</id>
     <name>CUE</name>
-    <vendor url="https://github.com/monogon-dev/intellij-cue/" email="intellij-publishers@monogon.dev">monogon</vendor>
+    <vendor url="https://cue.dev" email="contact@cue.dev">cue-labs</vendor>
     <resource-bundle>messages.cuelang</resource-bundle>
 
     <!-- Product and plugin compatibility requirements -->


### PR DESCRIPTION
Updates the vendor to match the move of the GitHub repository.
The JetBrains Marketplace team [already reassigned](https://plugins.jetbrains.com/vendor/cue-labs) the CUE plugin to the CUE org.