### PR TITLE
chore: update to 2026.1 rc, verify against 2026.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,8 +107,8 @@ intellijPlatform {
 
             // latest supported major version
             select {
-                sinceBuild = "253"
-                untilBuild = "253.*"
+                sinceBuild = "261"
+                untilBuild = "261.*"
                 types.set(listOf(IntelliJPlatformType.IntellijIdea))
             }
         }

--- a/gradle-261.properties
+++ b/gradle-261.properties
@@ -1,1 +1,1 @@
-ideVersion=261.21849.20
+ideVersion=261.22158.182


### PR DESCRIPTION
2026.1 will be released very soon. This PR updates to the 2026.1 release candidate and the plugin verifier to verify against 2026.1 and not 2025.3.